### PR TITLE
Prognoza szczegółowa oraz ogólna

### DIFF
--- a/APICommunication.js
+++ b/APICommunication.js
@@ -12,11 +12,11 @@ function APIRequestByCityName(city)
 }
 /*Język przestawiony w api na polski (&lang={pl}), ale nie zawuażyłam zmiany */
 
-function Getdata(APIpromise){
+async function Getdata(APIpromise){
     var code = [];
     const values = [];
     const body = document.querySelector('body');
-    fetch(APIpromise)
+    await fetch(APIpromise)
         .then( response => response.json())
         .then (APIdata => {
             if(APIdata.cod !== "200")

--- a/Forecast.js
+++ b/Forecast.js
@@ -1,5 +1,8 @@
 
+
+
 //funkcje pomocnicze
+
 const dayName = (dayNr)=>{
     switch(dayNr){
         case 0:
@@ -32,8 +35,8 @@ const iconUrlfromId = (iconId)=>{
 
 //utworzenie sekcji DetailedSection
 
-const createDetailedSection = (dataId)=>{
-
+const createDetailedSection = (cityName, dataId)=>{
+    
     let moment = data.find(el => el.dt === dataId);
     //console.log(moment);
     let detailedForecast = {
@@ -48,7 +51,7 @@ const createDetailedSection = (dataId)=>{
 
 
 
-    let detailDivs = document.querySelectorAll('#detail');
+    let detailDivs = document.querySelectorAll('.detail');
     
     detailDivs[0].innerHTML = `
     <figure>
@@ -83,7 +86,7 @@ const createDetailedSection = (dataId)=>{
     detailDivs[5].innerHTML = `
     <figure>
         <i class="wi wi-day-cloudy"></i>
-        <figcaption><b>Zachmurzenie</b> ${detailedForecast.clouds}m/s</figcaption>
+        <figcaption><b>Zachmurzenie</b> ${detailedForecast.clouds}%</figcaption>
     </figure>
     `
     let forecastHeader = document.getElementById('detailedHeader');
@@ -95,8 +98,6 @@ const createDetailedSection = (dataId)=>{
 const createShortSection = ()=>{
 
     let next5days = [];
-
-    
     let dayNr = -1;
     let previousMomentDay = -1;
 
@@ -154,7 +155,7 @@ const createShortSection = ()=>{
     let shortHumidityTags = document.querySelectorAll('.shortHumidity');
     let shortImages = document.querySelectorAll('.shortImg');
     let shortHeaders = document.querySelectorAll('.shortHeader');
-    let shortFigCaptions = document.querySelectorAll('#short figcaption')
+    let shortFigCaptions = document.querySelectorAll('.short figcaption')
 
     //console.log('shortCaptions');
     //console.log(shortFigCaptions);
@@ -165,16 +166,24 @@ const createShortSection = ()=>{
     }
 
     //console.log(next5days);
+    let imgIds = [];
+    let weatherDescriptions = [];
+    for (let i=0; i<data.length;i+=8){
+        imgIds.push(data[i].weather[0].icon);
+        weatherDescriptions.push(data[i].weather[0].description);
+    }
 
-    let imgIds = next5days.map(day=>{
-        return middleArrEl(day).weather[0].icon;
-    })
+
+
+    // let imgIds = next5days.map(day=>{
+    //     return middleArrEl(day).weather[0].icon;
+    // })
 
     //console.log(imgIds);
 
-    let weatherDescriptions = next5days.map(day=>{
-        return middleArrEl(day).weather[0].description;
-    })
+    // let weatherDescriptions = next5days.map(day=>{
+    //     return middleArrEl(day).weather[0].description;
+    // })
 
     //console.log(weatherDescriptions);
 
@@ -189,9 +198,17 @@ const createShortSection = ()=>{
         shortFigCaptions[i].innerHTML = weatherDescriptions[i];
     }
 
-
-
-
 }
 
+
+//Kliknięcie na kafelek short
+
+const weatherTileClick = function(e){
+    
+    let tileNumer = e.currentTarget.dataset.shortindex;
+    let dataId = data[tileNumer*8].dt;
+    let placeCity=document.getElementById('placeInput').value;
+    createDetailedSection(placeCity, dataId)
+    
+}
 

--- a/Forecast.js
+++ b/Forecast.js
@@ -38,7 +38,9 @@ const iconUrlfromId = (iconId)=>{
 const createDetailedSection = (cityName, dataId)=>{
     
     let moment = data.find(el => el.dt === dataId);
-    //console.log(moment);
+    console.log('drukuje moment');
+    console.log(moment);
+
     let detailedForecast = {
         weatherDescription: moment.weather[0].description,
         weatherIcon: moment.weather[0].icon,

--- a/index.html
+++ b/index.html
@@ -97,12 +97,12 @@
                 <h4 id="detailedHeader">Dane dla: </h4>
                 <div class="row justify-content-center">
                   <!---sekcja na prognozę szczegółową (dla jednego dnia)-->
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
-                  <div id='detail' class='col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
+                  <div  class='detail col-sm-4 col-md-3'>cokolwiek</div>
                 </div>
             </section>
             <div id="forecastBar" class="bar">
@@ -122,134 +122,135 @@
             <!--prognoza skrótowa-->
 
             <div class="row justify-content-center">
-                <div id="short" class="col-sm-4 col-md-3 col-lg-2" >
+                <div class="short col-sm-4 col-md-3 col-lg-2" data-shortIndex="0">
                     <h5 class="shortHeader">cokolwiek</h5>
                     <figure>
-                        <img class="shortImg" src="weather_icons/sun.svg">
+                        <img class="shortImg" src="http://openweathermap.org/img/wn/04d@2x.png">
                         <figcaption></figcaption>
                     </figure>
                     <table class="table">
                         <tbody>
                             <tr>
-                                <th>temperatura</th>
+                                <th><i class="wi wi-thermometer"></i></th>
                                 <td class="shortTemperature">100</td>
 
                             </tr>
                             <tr>
-                                <th>ciśnienie</th>
+                                <th><i class="wi wi-barometer"></i></th>
                                 <td class="shortPressure">100</td>
 
                             </tr>
                             <tr>
-                                <th>Wilgotność</th>
+                                <th><i class="wi wi-humidity"></i></th>
                                 <td class="shortHumidity">100</td>
 
                             </tr>
                         </tbody>
                     </table>
                 </div>
-                <div id="short" class="shortForecast col-sm-4 col-md-3 col-lg-2">
+                <div class="short shortForecast col-sm-4 col-md-3 col-lg-2" data-shortIndex="1">
                     <h5 class="shortHeader">cokolwiek</h5>
                     <figure>
-                        <img class="shortImg" src="weather_icons/sun.svg">
+                        <img class="shortImg" src="http://openweathermap.org/img/wn/04d@2x.png">
                         <figcaption></figcaption>
                     </figure>
                     <table class="table">
                             <tbody>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-thermometer"></i></th>
                                     <td class="shortTemperature">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-barometer"></i></th>
                                     <td class="shortPressure">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-humidity"></i></th>
                                     <td class="shortHumidity">100</td>
         
                                 </tr>
                             </tbody>
                     </table>
                 </div>
-                <div id="short" class="shortForecast col-sm-4 col-md-3 col-lg-2">
+                <div class="short shortForecast col-sm-4 col-md-3 col-lg-2" data-shortIndex="2">
                     <h5 class="shortHeader">cokolwiek</h5>
                     <figure>
-                        <img class="shortImg" src="weather_icons/sun.svg">
+                        <img class="shortImg" src="http://openweathermap.org/img/wn/04d@2x.png">
                         <figcaption></figcaption>
                     </figure>
                     <table class="table">
                             <tbody>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-thermometer"></i></th>
                                     <td class="shortTemperature">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-barometer"></i></th>
                                     <td class="shortPressure">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-humidity"></i></th>
                                     <td class="shortHumidity">100</td>
         
                                 </tr>
                             </tbody>
                     </table>
                 </div>
-                <div id="short" class="shortForecast col-sm-4 col-md-3 col-lg-2">
+                <div class="short shortForecast col-sm-4 col-md-3 col-lg-2" data-shortIndex="3">
                     <h5 class="shortHeader">cokolwiek</h5>
                     <figure>
-                        <img class="shortImg" src="weather_icons/sun.svg">
+                        <img class="shortImg" src="http://openweathermap.org/img/wn/04d@2x.png">
                         <figcaption></figcaption>
                     </figure>
                     <table class="table">
                             <tbody>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-thermometer"></i></th>
                                     <td class="shortTemperature">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-barometer"></i></th>
                                     <td class="shortPressure">100</td>
         
                                 </tr>
                                 <tr>
-                                    <th></th>
+                                    <th><i class="wi wi-humidity"></i></th>
                                     <td class="shortHumidity">100</td>
         
                                 </tr>
                             </tbody>
                     </table>
                 </div>
-                <div id="short" class="shortForecast col-sm-4 col-md-3 col-lg-2">
+                <div class="short shortForecast col-sm-4 col-md-3 col-lg-2" data-shortindex="4">
                     <h5 class="shortHeader">cokolwiek</h5>
                     <figure>
-                        <img class="shortImg" src="http://openweathermap.org/img/wn/10d@2x.png">
+                        <img class="shortImg" src="http://openweathermap.org/img/wn/04d@2x.png">
                         <figcaption></figcaption>
                     </figure>
                     <table class="table">
-                            <tbody>
-                                <tr>
-                                    <th></th>
-                                    <td class="shortTemperature">100</td>
-        
-                                </tr>
-                                <tr>
-                                    <th></th>
-                                    <td class="shortPressure">100</td>
-        
-                                </tr>
-                                <tr>
-                                    <th></th>
-                                    <td class="shortHumidity">100</td>
-                                 </tr>
-                             </tbody>
-                      </table>
+                        <tbody>
+                            <tr>
+                                <th><i class="wi wi-thermometer"></i></th>
+                                <td class="shortTemperature">100</td>
+    
+                            </tr>
+                            <tr>
+                                <th><i class="wi wi-barometer"></i></th>
+                                <td class="shortPressure">100</td>
+    
+                            </tr>
+                            <tr>
+                                <th><i class="wi wi-humidity"></i></th>
+                                <td class="shortHumidity">100</td>
+    
+                            </tr>
+                        </tbody>
+                </table>
                     </div>
                </div>
             </section>

--- a/main.js
+++ b/main.js
@@ -67,7 +67,7 @@ window.addEventListener('load', async function(e){
 sub.addEventListener('click', async function(e){
         await Getdata(APIRequestByCityName(placeInput.value));
         await createShortSection();
-        createDetailedSection(placeInput.value, data[0].dt_txt);
+        createDetailedSection(placeInput.value, data[0].dt);
 /*trzeba również dodać wybór wg daty*/
 /*trzeba rozważyć wszelakie błędy*/
 /*trzeba upewnić sie, że zajdzie walidacja przed pobraniem danych*/

--- a/main.js
+++ b/main.js
@@ -52,15 +52,32 @@ dateInput.addEventListener('input', function(e){
 /*potrzebna jeszcze walidacja daty*/
 /*POBIERANIE DANYCH DLA INPUTU MIASTA*/
 
+//Przy loadowaniu strony
+let defaultCity = 'Wrocław';
+window.addEventListener('load', async function(e){
+    await Getdata(APIRequestByCityName('Wrocław'));
+    console.log('logWindow');
+    console.log(data);
+    await createShortSection();
+    createDetailedSection(defaultCity, data[0].dt);
 
+});
+
+//Po kliknięciu submita
 sub.addEventListener('click', async function(e){
         await Getdata(APIRequestByCityName(placeInput.value));
         await createShortSection();
-        //uwaga: gdzieś 8 września przestanie działać:
-        createDetailedSection(1567771200);
+        createDetailedSection(placeInput.value, data[0].dt_txt);
 /*trzeba również dodać wybór wg daty*/
 /*trzeba rozważyć wszelakie błędy*/
 /*trzeba upewnić sie, że zajdzie walidacja przed pobraniem danych*/
 /*trzeba przemyśleć ASYNCHRONICZNOŚĆ!!!*/
 })
     
+
+//Po kliknięciu kafelka
+
+let weatherTiles = document.querySelectorAll('.short');
+weatherTiles.forEach(tile=>{
+    tile.addEventListener('click', weatherTileClick)
+})

--- a/style.css
+++ b/style.css
@@ -88,15 +88,18 @@ section{
 
 /* Prognoza ogólna */
 
-#short{
+.short{
     text-align: center;
+    margin: 10px;
+    transition: transform 0.5s;
+    padding: 5px;
 } 
 
-#short th{
+/* #short th{
     text-align: left;
-}
+} */
 
-#short h5{
+.short h5{
     font-family: 'Cantora One', sans-serif;
 }
 
@@ -108,6 +111,17 @@ section{
     font-size: 60px;
     padding: 50px;
     /* color: white; */
+}
+
+.short .wi{
+    font-size: 24px;
+    padding: 0;
+}
+
+.short:hover{
+    border: 1px solid white;
+    box-shadow: 0 0 3px white;
+    transform: scale(1.02)
 }
 
 /*ZMIANY Mateusz*/


### PR DESCRIPTION
Ikonki zamiast nagłówków w prognozie ogólnej
Strona domyślnie ładuje dane dla Wrocławia dla bieżącej godziny
Prognoza szczegółowa zmienia się przy kliknięciu kafelka (wyświetla dane
dla aktualnej godziny)